### PR TITLE
Fixed ServerTemplate structs Revision attribute to be integer

### DIFF
--- a/cm15/codegen_client.go
+++ b/cm15/codegen_client.go
@@ -1439,7 +1439,7 @@ type Cookbook struct {
 	Actions           []map[string]string `json:"actions,omitempty"`
 	CreatedAt         *RubyTime           `json:"created_at,omitempty"`
 	DownloadUrl       string              `json:"download_url,omitempty"`
-	Id                string              `json:"id,omitempty"`
+	Id                int                 `json:"id,omitempty"`
 	Links             []map[string]string `json:"links,omitempty"`
 	Metadata          string              `json:"metadata,omitempty"`
 	Name              string              `json:"name,omitempty"`
@@ -6290,7 +6290,7 @@ type RightScript struct {
 	Lineage     string              `json:"lineage,omitempty"`
 	Links       []map[string]string `json:"links,omitempty"`
 	Name        string              `json:"name,omitempty"`
-	Revision    string              `json:"revision,omitempty"`
+	Revision    int                 `json:"revision,omitempty"`
 	Source      string              `json:"source,omitempty"`
 	UpdatedAt   *RubyTime           `json:"updated_at,omitempty"`
 }
@@ -6804,7 +6804,7 @@ type RunnableBinding struct {
 	Links       []map[string]string `json:"links,omitempty"`
 	Position    int                 `json:"position,omitempty"`
 	Recipe      string              `json:"recipe,omitempty"`
-	RightScript string              `json:"right_script,omitempty"`
+	RightScript RightScript         `json:"right_script,omitempty"`
 	Sequence    string              `json:"sequence,omitempty"`
 }
 

--- a/cm15/codegen_client.go
+++ b/cm15/codegen_client.go
@@ -8012,7 +8012,7 @@ type ServerTemplate struct {
 	Lineage     string              `json:"lineage,omitempty"`
 	Links       []map[string]string `json:"links,omitempty"`
 	Name        string              `json:"name,omitempty"`
-	Revision    string              `json:"revision,omitempty"`
+	Revision    int                 `json:"revision,omitempty"`
 }
 
 //===== Locator


### PR DESCRIPTION
The ServerTemplate show call was failing with json: cannot unmarshal number into Go value of type string. This will fix that. The broken build is due to ca/api bug that was fixed in the pr https://github.com/rightscale/rsc/pull/36