### PR TITLE
SS FileUpload object Name is 'source' not file name

### DIFF
--- a/ss/examples/upload/main.go
+++ b/ss/examples/upload/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 	name := filepath.Base(*cat)
 	l := client.TemplateLocator(fmt.Sprintf("/designer/collections/%d/templates", *account))
-	upload := rsapi.FileUpload{Name: name, Filename: name, Reader: file}
+	upload := rsapi.FileUpload{Name: "source", Filename: name, Reader: file}
 	t, err := l.Create(&upload)
 	if err != nil {
 		fail("failed to create template: %s", err)


### PR DESCRIPTION
Addresses Issue #40 
FileUpload `Name` is "source". Otherwise, a 500 error happens on upload.
