### PR TITLE
IV-1637 Fix authentication to work through proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ vNext
 -------------------
 * Add cloud specific attributes to servers and instances
 * Fix issue with request timing logging
+* Go through proxy if http_proxy is set
 
 v3.0.2 / 2015-07-21
 -------------------

--- a/httpclient/http.go
+++ b/httpclient/http.go
@@ -106,7 +106,7 @@ func ShortToken() string {
 // newRawClient creates an http package Client taking into account both the parameters and package
 // variables.
 func newRawClient(noredirect bool) *http.Client {
-	tr := http.Transport{ResponseHeaderTimeout: ResponseHeaderTimeout}
+	tr := http.Transport{ResponseHeaderTimeout: ResponseHeaderTimeout, Proxy: http.ProxyFromEnvironment}
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: NoCertCheck}
 	c := http.Client{Transport: &tr}
 	if noredirect {

--- a/httpclient/http_test.go
+++ b/httpclient/http_test.go
@@ -170,4 +170,15 @@ var _ = Describe("HTTP client", func() {
 		})
 	})
 
+	// CAN'T DO: Proxy support must be tested using integration tests. See:
+	// https://go.googlesource.com/go/+/go1.4.2/src/net/http/transport.go#296 dealing
+	// with httpProxyEnv instantions. The env is read only once ever and the methods
+	// to reset this mechanism for testing purposes are internal to the http package.
+	// Context("with proxy", func() {
+	// 	BeforeEach(func() {
+	// 	  os.Setenv("http_proxy", "http://1.2.3.4:90")
+	// 		client = httpclient.New()
+	// 	})
+	//})
+
 })


### PR DESCRIPTION
http.ProxyFromEnvironment is what is normally used for the DefaultTransport, so this is just resetting this to the correct default.

Avoids issue where if http_proxy is set, authentication part was not going through proxy though subsequent requests were.
