### PR TITLE
Fix SS host string substitution for SS host names

### DIFF
--- a/rsapi/auth.go
+++ b/rsapi/auth.go
@@ -362,7 +362,7 @@ func (a *ssAuthenticator) SetHost(host string) {
 		a.host = host
 		return
 	}
-	elems[len(elems)-2] = strings.Replace(elems[len(elems)-2], "us", "selfservice", 1)
+	elems[len(elems)-2] = "selfservice"
 	ssLoginHostPrefix := strings.Join(elems, "-")
 	a.host = strings.Join(append([]string{ssLoginHostPrefix}, urlElems[1:]...), ".")
 }


### PR DESCRIPTION
Not all endpoints use the 'us-3.rightscale.com' style host. This commit
removes the assumption that there will be a 'us' substring in the login
host. Fixes #45.