### PR TITLE
Tl 434 fix references to old rs api docs

### DIFF
--- a/ss/examples/basic/main.go
+++ b/ss/examples/basic/main.go
@@ -1,6 +1,6 @@
 // This basic example illustrates how to setup a Self-Service client to make a simple
 // API call. The reference for the API can be found at
-// https://rs-api-docs.s3.amazonaws.com/selfservice/manager/index.html#/
+// http://reference.rightscale.com/selfservice/manager/index.html#/
 package main
 
 import (

--- a/ss/examples/basic/main.go
+++ b/ss/examples/basic/main.go
@@ -1,6 +1,6 @@
 // This basic example illustrates how to setup a Self-Service client to make a simple
 // API call. The reference for the API can be found at
-// https://s3.amazonaws.com/rs_api_docs/selfservice/manager/index.html#/
+// https://rs-api-docs.s3.amazonaws.com/selfservice/manager/index.html#/
 package main
 
 import (

--- a/ss/examples/upload/main.go
+++ b/ss/examples/upload/main.go
@@ -1,5 +1,5 @@
 // This upload example illustrates how to upload a CAT to the self-service designer service.
-// The reference for the API can be found at https://rs-api-docs.s3.amazonaws.com/selfservice/manager/index.html#/
+// The reference for the API can be found at http://reference.rightscale.com/selfservice/manager/index.html#/
 package main
 
 import (

--- a/ss/examples/upload/main.go
+++ b/ss/examples/upload/main.go
@@ -1,5 +1,5 @@
 // This upload example illustrates how to upload a CAT to the self-service designer service.
-// The reference for the API can be found at https://s3.amazonaws.com/rs_api_docs/selfservice/manager/index.html#/
+// The reference for the API can be found at https://rs-api-docs.s3.amazonaws.com/selfservice/manager/index.html#/
 package main
 
 import (


### PR DESCRIPTION
This is the correct link to access to this reference page. The old one is soon going to be invalid due to bucket migration.