### PR TITLE
Change type of local_disk_size attribute for InstanceType resource

### DIFF
--- a/cm15/attributes.json
+++ b/cm15/attributes.json
@@ -72,7 +72,7 @@
 	"last_name": "string",
 	"lineage": "string",
 	"links": "[]map[string]string",
-	"local_disk_size": "string",
+	"local_disk_size": "int",
 	"local_disks": "int",
 	"locked": "bool",
 	"long_description": "string",

--- a/cm15/codegen_client.go
+++ b/cm15/codegen_client.go
@@ -4749,7 +4749,7 @@ type InstanceType struct {
 	CpuSpeed        string              `json:"cpu_speed,omitempty"`
 	Description     string              `json:"description,omitempty"`
 	Links           []map[string]string `json:"links,omitempty"`
-	LocalDiskSize   string              `json:"local_disk_size,omitempty"`
+	LocalDiskSize   int                 `json:"local_disk_size,omitempty"`
 	LocalDisks      int                 `json:"local_disks,omitempty"`
 	Memory          string              `json:"memory,omitempty"`
 	Name            string              `json:"name,omitempty"`


### PR DESCRIPTION
Resource InstanceType currently has attribute local_disk_size set to string, but the actual json document is returning an int (not sure if this is cloud dependant or not). ex:
```json

{  
   "resource_uid":"1",
   "name":"small",
   "description":"canned type small",
   "memory":"1GB",
   "cpu_speed":"",
   "cpu_count":1,
   "cpu_architecture":null,
   "local_disks":0,
   "local_disk_size":0,
   "links":[  ],
   "actions":[  ]
},
{  
   "resource_uid":"3",
   "name":"small (memory reserved)",
   "description":"canned type small",
   "memory":"1GB (Memory Reservation)",
   "cpu_speed":"1Ghz",
   "cpu_count":1,
   "cpu_architecture":null,
   "local_disks":1,
   "local_disk_size":10,
   "links":[  ],
   "actions":[  ]
}

```

with the attribute defined as string was getting "cannot unmarshal number into Go value of type string". 