### PR TITLE
SS-2670 Fix array query params in metadata.

### DIFF
--- a/ca/cac/codegen_metadata.go
+++ b/ca/cac/codegen_metadata.go
@@ -881,7 +881,7 @@ var GenMetadata = map[string]*metadata.Resource{
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "cloud_bill_filters",
+						Name:        "cloud_bill_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -897,7 +897,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "filter_types",
+						Name:        "filter_types[]",
 						Description: `Restricts the filter options to the specified keys.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -985,7 +985,7 @@ var GenMetadata = map[string]*metadata.Resource{
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "cloud_bill_filters",
+						Name:        "cloud_bill_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1001,7 +1001,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "group",
+						Name:        "group[]",
 						Description: `The fields to group the results by.`,
 						Type:        "[][]string",
 						Location:    metadata.QueryParam,
@@ -1451,7 +1451,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1475,7 +1475,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1566,7 +1566,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1649,7 +1649,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1764,7 +1764,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1788,7 +1788,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1927,7 +1927,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "filter_types",
+						Name:        "filter_types[]",
 						Description: `The filter types to get results for.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1935,7 +1935,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -1959,7 +1959,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2727,7 +2727,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -2735,7 +2735,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "metrics",
+						Name:        "metrics[]",
 						Description: `The metrics to get results for. Descriptions of the individual metrics can be found in the Metrics media type.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2876,7 +2876,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "group",
+						Name:        "group[]",
 						Description: `The fields to group the results by.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2884,7 +2884,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -2900,7 +2900,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "metrics",
+						Name:        "metrics[]",
 						Description: `The metrics to get results for. Descriptions of the individual metrics can be found in the Metrics media type.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2916,7 +2916,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3051,7 +3051,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						ValidValues: []string{"hour", "day", "week", "month"},
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -3067,7 +3067,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "metrics",
+						Name:        "metrics[]",
 						Description: `The metrics to get results for. Descriptions of the individual metrics can be found in the Metrics media type.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3235,7 +3235,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						ValidValues: []string{"hour", "day", "week", "month"},
 					},
 					&metadata.ActionParam{
-						Name:        "group",
+						Name:        "group[]",
 						Description: `The fields to group the results by.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3243,7 +3243,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -3267,7 +3267,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "metrics",
+						Name:        "metrics[]",
 						Description: `The metrics to get results for. Descriptions of the individual metrics can be found in the Metrics media type.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3283,7 +3283,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3341,7 +3341,7 @@ var GenMetadata = map[string]*metadata.Resource{
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "instance_filters",
+						Name:        "instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -3389,7 +3389,7 @@ var GenMetadata = map[string]*metadata.Resource{
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "instance_usage_period_filters",
+						Name:        "instance_usage_period_filters[]",
 						Description: `Filters the instance usages by instance key.`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -3961,7 +3961,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3969,7 +3969,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "reserved_instance_filters",
+						Name:        "reserved_instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -4060,7 +4060,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "reserved_instance_filters",
+						Name:        "reserved_instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -4143,7 +4143,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "reserved_instance_filters",
+						Name:        "reserved_instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -4274,7 +4274,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4282,7 +4282,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "reserved_instance_filters",
+						Name:        "reserved_instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,
@@ -4421,7 +4421,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "filter_types",
+						Name:        "filter_types[]",
 						Description: `The filter types to get results for.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4445,7 +4445,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "order",
+						Name:        "order[]",
 						Description: `The fields to order the results by. If '-' is in front of the field name allows it to be sorted in descending order.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4453,7 +4453,7 @@ var GenMetadata = map[string]*metadata.Resource{
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "reserved_instance_filters",
+						Name:        "reserved_instance_filters[]",
 						Description: `The filters to apply`,
 						Type:        "[]*Filter",
 						Location:    metadata.QueryParam,

--- a/cm15/codegen_metadata.go
+++ b/cm15/codegen_metadata.go
@@ -76,7 +76,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -275,7 +275,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -653,7 +653,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1137,7 +1137,7 @@ Optional parameters:
 						NonBlank:    true,
 					},
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1563,7 +1563,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1799,7 +1799,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1892,7 +1892,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2183,7 +2183,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2665,7 +2665,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2817,7 +2817,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3037,7 +3037,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3259,7 +3259,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3358,7 +3358,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -3890,7 +3890,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4111,7 +4111,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4196,7 +4196,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -4947,7 +4947,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -5110,7 +5110,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -5318,7 +5318,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -5475,7 +5475,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -5798,7 +5798,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -6002,7 +6002,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -6216,7 +6216,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -6399,7 +6399,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -6594,7 +6594,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -6777,7 +6777,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -7158,7 +7158,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -7291,7 +7291,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -7393,7 +7393,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -7513,7 +7513,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -7773,7 +7773,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -8185,7 +8185,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -8604,7 +8604,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -8864,7 +8864,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -9085,7 +9085,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -9836,7 +9836,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -10548,7 +10548,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -11362,7 +11362,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -11951,7 +11951,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -12362,7 +12362,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -12652,7 +12652,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -12841,7 +12841,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -13402,7 +13402,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -13745,7 +13745,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -14008,7 +14008,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -14259,7 +14259,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -14363,7 +14363,7 @@ Optional parameters:
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,

--- a/gen/writers/metadata.go
+++ b/gen/writers/metadata.go
@@ -124,7 +124,7 @@ const actionMetadataTmpl = `&metadata.Action {
 				Payload: "{{.Payload.Name}}",{{end}}
 				APIParams: []*metadata.ActionParam{ {{range .Params}}
 					&metadata.ActionParam{
-						Name: "{{.Name}}",
+						Name: {{if eq .Location 1}}"{{.QueryName}}"{{else}}"{{.Name}}"{{end}},
 						Description: ` + "`" + `{{escapeBackticks .Description}}` + "`" + `,
 						Type: "{{.Signature}}",
 						Location: {{location .}},

--- a/ss/ssc/codegen_metadata.go
+++ b/ss/ssc/codegen_metadata.go
@@ -54,7 +54,7 @@ to use in your own integration.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by group, so that only AccountPreferences belonging to that group are returned`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -200,7 +200,7 @@ and can launch them to create Executions in the Manager application.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `An optional list of Application IDs to retrieve. If not specified, all are returned.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1382,7 +1382,7 @@ and can launch them to create Executions in the Manager application.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `The Application IDs to delete`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1669,7 +1669,7 @@ and can launch them to create Executions in the Manager application.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: ``,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1891,7 +1891,7 @@ Users who are not members of the admin role need to specify a filter with their 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by user, so that only UserPreference belonging to that user are returned. Use "me" as a shortcut for the current user ID.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -2107,7 +2107,7 @@ It is also used to validate values saved in UserPreference.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by category and/or name`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,

--- a/ss/ssd/codegen_metadata.go
+++ b/ss/ssd/codegen_metadata.go
@@ -319,7 +319,7 @@ Note: deleting a Schedule from Designer doesn't remove it from the applications 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `The IDs of the Schedules to delete`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -365,7 +365,7 @@ attribute inside of a CAT file.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `An optional list of template IDs to retrieve`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -514,7 +514,7 @@ attribute inside of a CAT file.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `The IDs of the Template to delete`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,

--- a/ss/ssm/codegen_metadata.go
+++ b/ss/ssm/codegen_metadata.go
@@ -71,7 +71,7 @@ Self-Service.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by status, syntax is ["status==running"]`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -79,7 +79,7 @@ Self-Service.`,
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `An optional list of execution IDs to retrieve`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1215,7 +1215,7 @@ Note: using this option may leave cloud resources running that must manually be 
 						NonBlank:  false,
 					},
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to delete`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1341,7 +1341,7 @@ Note: using this option may leave cloud resources running that must manually be 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to launch`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1374,7 +1374,7 @@ Note: using this option may leave cloud resources running that must manually be 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to start`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1407,7 +1407,7 @@ Note: using this option may leave cloud resources running that must manually be 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to stop`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1440,7 +1440,7 @@ Note: using this option may leave cloud resources running that must manually be 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to terminate`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1572,7 +1572,7 @@ Note: using this option may leave cloud resources running that must manually be 
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `List of execution IDs to run`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1636,7 +1636,7 @@ available via the API/UI and are not distributed externally to users.`,
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by Execution`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1644,7 +1644,7 @@ available via the API/UI and are not distributed externally to users.`,
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `The Notification IDs to return`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1725,7 +1725,7 @@ Once a CAT is Terminated, a sequence of Operations is run as [explained here](ht
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by Execution ID or status`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1733,7 +1733,7 @@ Once a CAT is Terminated, a sequence of Operations is run as [explained here](ht
 						NonBlank:    false,
 					},
 					&metadata.ActionParam{
-						Name:        "ids",
+						Name:        "ids[]",
 						Description: `IDs of operations to filter on`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,
@@ -1907,7 +1907,7 @@ All DateTimes must be passed in [ISO-8601 format](https://en.wikipedia.org/wiki/
 				},
 				APIParams: []*metadata.ActionParam{
 					&metadata.ActionParam{
-						Name:        "filter",
+						Name:        "filter[]",
 						Description: `Filter by execution id or execution creator (user) id.`,
 						Type:        "[]string",
 						Location:    metadata.QueryParam,


### PR DESCRIPTION
This is a follow up PR to https://github.com/rightscale/rsc/pull/53 and differentiates between QueryParam and PayloadParam in the name in APIParams metadata.