### PR TITLE
SS-3010 Support context-aware http requests.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -43,6 +43,10 @@
 			"Rev": "d04eebe26072b09f780b43c72c6df71b12b8d105"
 		},
 		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "66f0418ca41253f8d1a024eb9754e9441a8e79b9"
+		},
+		{
 			"ImportPath": "gopkg.in/alecthomas/kingpin.v2",
 			"Comment": "v2.0.12",
 			"Rev": "639879d6110b1b0409410c7b737ef0bb18325038"

--- a/rsapi/http.go
+++ b/rsapi/http.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strconv"
 
+	"golang.org/x/net/context"
+
 	"github.com/rightscale/rsc/metadata"
 )
 
@@ -142,6 +144,22 @@ func (a *API) PerformRequest(req *http.Request) (*http.Response, error) {
 		}
 	}
 	resp, err := a.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, err
+}
+
+// PerformRequestWithContext performs everything the PerformRequest does but is also context-aware.
+func (a *API) PerformRequestWithContext(ctx context.Context, req *http.Request) (*http.Response, error) {
+	// Sign last so auth headers don't get printed or logged
+	if a.Auth != nil {
+		if err := a.Auth.Sign(req); err != nil {
+			return nil, err
+		}
+	}
+	resp, err := a.Client.DoWithContext(ctx, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds support for using golang.org/x/net/context with HTTP requests. It can be used to cancel requests after certain period.