### PR TITLE
SS-3009 Use account ID with token authenticator.

### DIFF
--- a/rsapi/auth.go
+++ b/rsapi/auth.go
@@ -61,14 +61,9 @@ func NewOAuthAuthenticator(token string, accountID int) Authenticator {
 // NewTokenAuthenticator returns an authenticator that use an oauth access token to do authentication.
 // This is useful if the oauth handshake has already happened.
 // Use the OAuthAuthenticator to use a refresh token and have the authenticator do the handshake.
-func NewTokenAuthenticator(token string) Authenticator {
-	return &tokenAuthenticator{token: token}
-}
-
-// NewTokenAuthenticatorWithAccountID returns an authenticator that uses an oauth access token to do authentication.
-// This is similar to NewTokenAuthenticator but also accepts the account ID and sets the account ID
-// in the X-Account header.
-func NewTokenAuthenticatorWithAccountID(token string, accountID int) Authenticator {
+// Specifying the accountID is only required if the API requires the "X-Account" header to be set
+// (this is true of CM 1.6 at the moment).
+func NewTokenAuthenticator(token string, accountID int) Authenticator {
 	return &tokenAuthenticator{token: token, accountID: accountID}
 }
 

--- a/rsapi/rsapi.go
+++ b/rsapi/rsapi.go
@@ -113,7 +113,7 @@ func FromCommandLine(cmdLine *cmd.CommandLine) (*API, error) {
 		}
 		client = New(cmdLine.Host, auth)
 	} else if cmdLine.OAuthAccessToken != "" {
-		auth := NewTokenAuthenticator(cmdLine.OAuthAccessToken)
+		auth := NewTokenAuthenticator(cmdLine.OAuthAccessToken, cmdLine.Account)
 		if ss {
 			auth = NewSSAuthenticator(auth, cmdLine.Account)
 		}


### PR DESCRIPTION
The token authenticator doesn't send the X-Account header. This is
required for the CM16 API. So added a NewTokenAuthenticatorWithAccountID
function which will set the account ID and use it in the X-Account
header upon signing the request if provided.