### PR TITLE
Attribute type for Publication.CommitMessage was incorrect

### DIFF
--- a/cm15/attributes.json
+++ b/cm15/attributes.json
@@ -14,7 +14,7 @@
 	"cloud_type": "string",
 	"comments_emailed": "bool",
 	"comments_enabled": "bool",
-	"commit_message": "string",
+	"commit_message": "map[string]interface{}",
 	"commit_reference": "string",
 	"committed": "bool",
 	"company": "string",

--- a/cm15/codegen_client.go
+++ b/cm15/codegen_client.go
@@ -7486,17 +7486,17 @@ func (loc *PreferenceLocator) Update(preference *PreferenceParam) error {
 // A Publication is a revisioned component shared with a set of Account Groups.
 // If shared with your account, it can be imported in to your account.
 type Publication struct {
-	Actions       []map[string]string `json:"actions,omitempty"`
-	CommitMessage string              `json:"commit_message,omitempty"`
-	ContentType   string              `json:"content_type,omitempty"`
-	CreatedAt     *RubyTime           `json:"created_at,omitempty"`
-	Description   string              `json:"description,omitempty"`
-	Links         []map[string]string `json:"links,omitempty"`
-	Name          string              `json:"name,omitempty"`
-	Publisher     string              `json:"publisher,omitempty"`
-	Revision      int                 `json:"revision,omitempty"`
-	RevisionNotes string              `json:"revision_notes,omitempty"`
-	UpdatedAt     *RubyTime           `json:"updated_at,omitempty"`
+	Actions       []map[string]string    `json:"actions,omitempty"`
+	CommitMessage map[string]interface{} `json:"commit_message,omitempty"`
+	ContentType   string                 `json:"content_type,omitempty"`
+	CreatedAt     *RubyTime              `json:"created_at,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Links         []map[string]string    `json:"links,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	Publisher     string                 `json:"publisher,omitempty"`
+	Revision      int                    `json:"revision,omitempty"`
+	RevisionNotes string                 `json:"revision_notes,omitempty"`
+	UpdatedAt     *RubyTime              `json:"updated_at,omitempty"`
 }
 
 // Locator returns a locator for the given resource


### PR DESCRIPTION
While working with publications noticed the type was wrong. Example:
~~~
rsc cm15 index /api/publications 'filter[]=name==RL10 Linux Setup Hostname' | python -m json.tool
[
    {
        "actions": [
            {
                "rel": "import"
            }
        ],
        "commit_message": {
            "text": "Sync with github repo",
            "time": "2015/09/24 23:40:45 +0000",
            "user": "efrain@rightscale.com"
        },
        "content_type": "RightScript",
        "created_at": "2015/09/25 03:01:37 +0000",
        "description": "Changes the hostname of the server.",
        "links": [
            {
                "href": "/api/publications/209498",
                "rel": "self"
            },
            {
                "href": "/api/publication_lineages/55956",
                "rel": "lineage"
            }
        ],
        "name": "RL10 Linux Setup Hostname",
        "publisher": "RightScale",
        "revision": 2,
        "revision_notes": null,
        "updated_at": "2015/10/02 23:55:23 +0000"
    }
]
~~~