### PR TITLE
Ss 3011 respect scheme in request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cm15/examples/auditail/auditail
 cm15/examples/basic/basic
 cm15/examples/rsssh/rsssh
 ss/examples/basic/basic
+vendor/

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ to make a series of requests.
 
 The `log` package exposes a `Logger` variable of type `log15.Logger`. This logger is used
 by rsc to log API requests made to external services. Configure the logger handler
-to enable logging. The [log15](https://godoc.org/gopkg.in/inconshreveable/log15.v2) package comes
+to enable logging. The [log15](https://godoc.org/github.com/inconshreveable/log15) package comes
 with a number of default handlers including a file and a syslog handlers.
 
 Configuring the `log` package to log to the file `/var/log/myapp.log` would look like:
@@ -384,7 +384,7 @@ if err != nil {
 }
 log.Logger.SetHandler(handler)
 ```
-Consult the [log15](https://godoc.org/gopkg.in/inconshreveable/log15.v2) GoDocs for more information.
+Consult the [log15](https://godoc.org/github.com/inconshreveable/log15) GoDocs for more information.
 
 ### Locators
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d233334b81c32e035ac64cd44a535bf49008ab8c9f4788f5071751f03a91f33a
-updated: 2016-08-22T11:54:33.435622691-07:00
+hash: 0368a8cc3269bb70498989e8c83d736bd6b53451962b6470dd2153e1ba8138d2
+updated: 2016-09-06T13:50:52.202698-07:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -15,6 +15,8 @@ imports:
   version: 68415e7123da32b07eab49c96d2c4d6158360e9b
   subpackages:
   - proto
+- name: github.com/inconshreveable/log15
+  version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
 - name: github.com/mattn/go-colorable
   version: 40e4aedc8fabf8c23e040057540867186712faa5
 - name: github.com/mattn/go-isatty
@@ -59,7 +61,7 @@ imports:
   - context
   - context/ctxhttp
 - name: gopkg.in/alecthomas/kingpin.v2
-  version: e5900212cbf65b181d3d8e08308ef06a01d117cf
+  version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
 - name: gopkg.in/inconshreveable/log15.v2
   version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0368a8cc3269bb70498989e8c83d736bd6b53451962b6470dd2153e1ba8138d2
-updated: 2016-09-06T13:50:52.202698-07:00
+hash: 5152df8a440ee656e3c1694e39d105db2e927f7020dcbd02d443d3eb5a4de92a
+updated: 2016-09-06T15:06:11.312724078-07:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -11,12 +11,16 @@ imports:
   version: 6b4e7dc5e3143b85ea77909c72caf89416fc2915
 - name: github.com/coddingtonbear/go-simplejson
   version: a582018feafb39c4884d1b03cad98b91e2804276
+- name: github.com/go-stack/stack
+  version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/golang/protobuf
   version: 68415e7123da32b07eab49c96d2c4d6158360e9b
   subpackages:
   - proto
 - name: github.com/inconshreveable/log15
-  version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
+  version: f1f14b426c23e20a73468078b52d0713a16a132a
+  subpackages:
+  - term
 - name: github.com/mattn/go-colorable
   version: 40e4aedc8fabf8c23e040057540867186712faa5
 - name: github.com/mattn/go-isatty
@@ -60,11 +64,10 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
+- name: golang.org/x/sys
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  subpackages:
+  - unix
 - name: gopkg.in/alecthomas/kingpin.v2
   version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
-- name: gopkg.in/inconshreveable/log15.v2
-  version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
-  subpackages:
-  - stack
-  - term
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,5 +29,5 @@ import:
   - context/ctxhttp
 - package: gopkg.in/alecthomas/kingpin.v2
   version: ^2.0.12
-- package: gopkg.in/inconshreveable/log15.v2
+- package: github.com/inconshreveable/log15
   version: ^2.10.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,4 +30,3 @@ import:
 - package: gopkg.in/alecthomas/kingpin.v2
   version: ^2.0.12
 - package: github.com/inconshreveable/log15
-  version: ^2.10.0

--- a/httpclient/http.go
+++ b/httpclient/http.go
@@ -175,10 +175,12 @@ func (d *dumpClient) DoHiddenWithContext(ctx context.Context, req *http.Request)
 
 // doImp actually performs the HTTP request logging according to the various settings.
 func (d *dumpClient) doImp(req *http.Request, hidden bool, ctx context.Context) (*http.Response, error) {
-	if Insecure {
-		req.URL.Scheme = "http"
-	} else {
-		req.URL.Scheme = "https"
+	if req.URL.Scheme == "" {
+		if Insecure {
+			req.URL.Scheme = "http"
+		} else {
+			req.URL.Scheme = "https"
+		}
 	}
 	req.Header.Set("User-Agent", UA)
 

--- a/log/doc.go
+++ b/log/doc.go
@@ -4,6 +4,6 @@ The default behavior in application mode consists of logging messages with sever
 to Stderr.
 The default behavior in library mode consists of not logging anything.
 The Logger variable can be used to set the logger behavior, for example by changing its handler.
-See https://godoc.org/gopkg.in/inconshreveable/log15.v2 for a list of available handlers.
+See https://godoc.org/github.com/inconshreveable/log15 for a list of available handlers.
 */
 package log

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,6 @@
 package log
 
-import "gopkg.in/inconshreveable/log15.v2"
+import "github.com/inconshreveable/log15"
 
 var (
 	// Logger is the main rsc logger. Configure its handler as appropriate.

--- a/rsapi/rsapi.go
+++ b/rsapi/rsapi.go
@@ -21,9 +21,6 @@ type (
 		Client                httpclient.HTTPClient // Underlying http client (not used for authentication requests as these necessitate special redirect handling)
 		FetchLocationResource bool                  // Whether to fetch resource pointed by Location header
 		Metadata              APIMetadata           // Generated API metadata
-
-		insecure bool // Whether HTTP should be used instead of HTTPS (used by RL10 proxied requests)
-		// Use Insecure method to set to true.
 	}
 )
 


### PR DESCRIPTION
Modifies the HTTP client so that if a request explicitly states a scheme (HTTP or HTTPS) then we will use the scheme instead of the 'Insecure' flag.