### PR TITLE
Support OAuth/refresh token from config

### DIFF
--- a/command_line.go
+++ b/command_line.go
@@ -88,6 +88,9 @@ func ParseCommandLine(app *kingpin.Application) (*cmd.CommandLine, error) {
 			if cmdLine.Host == "" {
 				cmdLine.Host = config.LoginHost
 			}
+			if len(config.RefreshToken) > 0 {
+				cmdLine.OAuthToken = config.RefreshToken
+			}
 		}
 	}
 	cmdLine.Command = cmd

--- a/config.go
+++ b/config.go
@@ -28,6 +28,9 @@ func LoadConfig(path string) (*ClientConfig, error) {
 		return nil, err
 	}
 	config.Password, err = Decrypt(config.Password)
+	if err != nil {
+		return nil, err
+	}
 	config.RefreshToken, err = Decrypt(config.RefreshToken)
 	return &config, err
 }

--- a/config.go
+++ b/config.go
@@ -28,16 +28,23 @@ func LoadConfig(path string) (*ClientConfig, error) {
 		return nil, err
 	}
 	config.Password, err = Decrypt(config.Password)
+	config.RefreshToken, err = Decrypt(config.RefreshToken)
 	return &config, err
 }
 
-// Save config encrypts the password and persists the config to file
+// Save config encrypts the password and/or refresh token;
+// persists the config to file
 func (cfg *ClientConfig) Save(path string) error {
-	encrypted, err := Encrypt(cfg.Password)
+	encrypted_password, err := Encrypt(cfg.Password)
 	if err != nil {
 		return fmt.Errorf("Failed to encrypt password: %s", err)
 	}
-	cfg.Password = encrypted
+	cfg.Password = encrypted_password
+	encrypted_refresh, err := Encrypt(cfg.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("Failed to encrypt refresh token: %s", err)
+	}
+	cfg.RefreshToken = encrypted_refresh
 	bytes, err := json.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("Failed to serialize config: %s", err)

--- a/config.go
+++ b/config.go
@@ -9,10 +9,11 @@ import (
 
 // ClientConfig is the basic configuration settings required by all clients.
 type ClientConfig struct {
-	Account   int    // RightScale account ID
-	LoginHost string // RightScale API login host, e.g. "us-3.rightscale.com"
-	Email     string // RightScale API login email
-	Password  string // RightScale API login password
+	Account      int    // RightScale account ID
+	LoginHost    string // RightScale API login host, e.g. "us-3.rightscale.com"
+	Email        string // RightScale API login email
+	Password     string // RightScale API login password
+	RefreshToken string // RightScale API refresh token
 }
 
 // LoadConfig loads the client configuration from disk
@@ -51,7 +52,7 @@ func (cfg *ClientConfig) Save(path string) error {
 // CreateConfig creates a configuration file and saves it to the file at the given path.
 func CreateConfig(path string) error {
 	config, _ := LoadConfig(path)
-	var emailDef, passwordDef, accountDef, hostDef string
+	var emailDef, passwordDef, accountDef, hostDef, refreshTokenDef string
 	if config != nil {
 		yn := PromptConfirmation("Found existing configuration file %v, overwrite? (y/N): ", path)
 		if yn != "y" {
@@ -65,11 +66,12 @@ func CreateConfig(path string) error {
 			config.LoginHost = "my.rightscale.com"
 		}
 		hostDef = fmt.Sprintf(" (%v)", config.LoginHost)
+		refreshTokenDef = fmt.Sprintf(" (%v)", config.RefreshToken)
 	} else {
 		config = &ClientConfig{}
 	}
 
-	fmt.Fprintf(out, "Account id%v: ", accountDef)
+	fmt.Fprintf(out, "Account ID%v: ", accountDef)
 	var newAccount string
 	fmt.Fscanln(in, &newAccount)
 	if newAccount != "" {
@@ -99,6 +101,13 @@ func CreateConfig(path string) error {
 	fmt.Fscanln(in, &newLoginHost)
 	if newLoginHost != "" {
 		config.LoginHost = newLoginHost
+	}
+
+	fmt.Fprintf(out, "API Refresh Token%v: ", refreshTokenDef)
+	var newRefreshToken string
+	fmt.Fscanln(in, &newRefreshToken)
+	if newRefreshToken != "" {
+		config.RefreshToken = newRefreshToken
 	}
 
 	err := config.Save(path)

--- a/config_test.go
+++ b/config_test.go
@@ -71,6 +71,7 @@ var _ = Describe("Config", func() {
 					Ω(config.LoginHost).Should(BeZero())
 					Ω(config.Email).Should(BeZero())
 					Ω(config.Password).Should(BeZero())
+					Ω(config.RefreshToken).Should(BeZero())
 				})
 			})
 
@@ -80,11 +81,12 @@ var _ = Describe("Config", func() {
 					host     string
 					email    string
 					password string
+					refresh  string
 				)
 
 				JustBeforeEach(func() {
-					var cfg = fmt.Sprintf(`{"Account":%d,"Email":"%s","LoginHost":"%s","Password":"%s"}`,
-						account, email, host, password)
+					var cfg = fmt.Sprintf(`{"Account":%d,"Email":"%s","LoginHost":"%s","Password":"%s","RefreshToken":"%s"}`,
+						account, email, host, password, refresh)
 					tempFile.WriteString(cfg)
 					config, err = LoadConfig(path)
 				})
@@ -180,7 +182,7 @@ var _ = Describe("Config", func() {
 
 				Context("which contains a valid config", func() {
 					BeforeEach(func() {
-						var cfg = `{"Account":2,"Email":"test@test.com","LoginHost":"s","Password":"OlVr2Xv9jZfg1zf+LACM+WJNnFxg4Bm46Yc/kA=="}`
+						var cfg = `{"Account":2,"Email":"test@test.com","LoginHost":"s","Password":"OlVr2Xv9jZfg1zf+LACM+WJNnFxg4Bm46Yc/kA==","RefreshToken":"1edda1a7fbde9eb1a3ae6ab8980f60183b5c71ca"}`
 						tempFile.WriteString(cfg)
 					})
 
@@ -221,13 +223,14 @@ var _ = Describe("Config", func() {
 							email    string
 							password string
 							host     string
+							refresh  string
 						)
 
 						Context("given an incorrect account", func() {
 							BeforeEach(func() {
 								account = "foo"
-								var inputs = fmt.Sprintf("%s\n%s\n%s\n%s\n",
-									account, email, password, host)
+								var inputs = fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
+									account, email, password, host, refresh)
 								testIn = bytes.NewReader([]byte(inputs))
 							})
 
@@ -243,8 +246,9 @@ var _ = Describe("Config", func() {
 								email = "test@test.com"
 								password = "tok"
 								host = "host"
-								var inputs = fmt.Sprintf("%s\n%s\n%s\n%s\n",
-									account, email, password, host)
+								refresh = "1edda1a7fbde9eb1a3ae6ab8980f60183b5c71ca"
+								var inputs = fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
+									account, email, password, host, refresh)
 								testIn = bytes.NewReader([]byte(inputs))
 							})
 
@@ -256,6 +260,7 @@ var _ = Describe("Config", func() {
 								Ω(config.Email).Should(Equal(email))
 								Ω(config.Password).Should(Equal(password))
 								Ω(config.LoginHost).Should(Equal(host))
+								Ω(config.RefreshToken).Should(Equal(refresh))
 							})
 						})
 					})

--- a/config_test.go
+++ b/config_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Config", func() {
 
 				Context("which contains a valid config", func() {
 					BeforeEach(func() {
-						var cfg = `{"Account":2,"Email":"test@test.com","LoginHost":"s","Password":"OlVr2Xv9jZfg1zf+LACM+WJNnFxg4Bm46Yc/kA==","RefreshToken":"1edda1a7fbde9eb1a3ae6ab8980f60183b5c71ca"}`
+						var cfg = `{"Account":2,"Email":"test@test.com","LoginHost":"s","Password":"OlVr2Xv9jZfg1zf+LACM+WJNnFxg4Bm46Yc/kA==","RefreshToken":"P+YuzH1milj3Od0Vd1tbQPAKWrVqXpRbTTtdeBc2U4HdH/tL2LqXEqp9OhDtWXB5slRWlZSjTVpjDjp/kpY9GJQX8D77nrY1"}`
 						tempFile.WriteString(cfg)
 					})
 
@@ -246,7 +246,7 @@ var _ = Describe("Config", func() {
 								email = "test@test.com"
 								password = "tok"
 								host = "host"
-								refresh = "1edda1a7fbde9eb1a3ae6ab8980f60183b5c71ca"
+								refresh = "1ecea8a3fbce2eb3a3be6ac8180f60182b5c81cd"
 								var inputs = fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n",
 									account, email, password, host, refresh)
 								testIn = bytes.NewReader([]byte(inputs))

--- a/config_test.go
+++ b/config_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Config", func() {
 
 					It("exits without prompting for new values", func() {
 						Ω(testOut.String()).Should(ContainSubstring("Exiting"))
-						Ω(testOut.String()).ShouldNot(ContainSubstring("Account id"))
+						Ω(testOut.String()).ShouldNot(ContainSubstring("Account ID"))
 					})
 
 					Context("replying yes to the confirmation prompt", func() {
@@ -200,7 +200,7 @@ var _ = Describe("Config", func() {
 
 						It("prompts for new values", func() {
 							Ω(testOut.String()).ShouldNot(ContainSubstring("Exiting"))
-							Ω(testOut.String()).Should(ContainSubstring("Account id"))
+							Ω(testOut.String()).Should(ContainSubstring("Account ID"))
 						})
 					})
 				})


### PR DESCRIPTION
Absolute minimum code to support usage of a refresh token within the config file if it exists. User can now set the refresh token using `rsc setup`. The main advantage is that no extra cli options are needed for users that use OAuth2 when consuming `~/.rsc` or via `--config`.

Addresses issue #77.