### PR TITLE
SS-4680_fix_concurrent_map_write_crash

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rightscale/rsc/rsapi"
 )
 
-// Metadata synthetized from all CA APIs metadata
-var GenMetadata map[string]*metadata.Resource
+// Metadata synthetized from all CA APIs metadata; setup once
+var GenMetadata = setupMetadata()
 
 // API is the CA 1.0 common client to all cloud analytics APIs.
 type API struct {
@@ -24,7 +24,6 @@ func FromCommandLine(cmdLine *cmd.CommandLine) (*API, error) {
 	if err != nil {
 		return nil, err
 	}
-	setupMetadata()
 	api.Host = apiHostFromLogin(cmdLine.Host)
 	api.Metadata = GenMetadata
 	return &API{api}, nil
@@ -33,7 +32,6 @@ func FromCommandLine(cmdLine *cmd.CommandLine) (*API, error) {
 // New returns a CA API client.
 func New(h string, a rsapi.Authenticator) *API {
 	api := rsapi.New(h, a)
-	setupMetadata()
 	api.Metadata = GenMetadata
 	return &API{API: api}
 }
@@ -59,9 +57,10 @@ func apiHostFromLogin(host string) string {
 }
 
 // Initialize GenMetadata from each CA API generated metadata
-func setupMetadata() {
-	GenMetadata = map[string]*metadata.Resource{}
+func setupMetadata() (result map[string]*metadata.Resource) {
+	result = make(map[string]*metadata.Resource)
 	for n, r := range cac.GenMetadata {
-		GenMetadata[n] = r
+		result[n] = r
 	}
+	return
 }

--- a/ca/commands.go
+++ b/ca/commands.go
@@ -17,7 +17,6 @@ var commandValues rsapi.ActionCommands
 // RegisterCommands registers all commands with kinpin application.
 func RegisterCommands(registrar rsapi.APICommandRegistrar) {
 	commandValues = rsapi.ActionCommands{}
-	setupMetadata()
 	registrar.RegisterActionCommands(APIName, GenMetadata, commandValues)
 }
 

--- a/ss/commands.go
+++ b/ss/commands.go
@@ -17,7 +17,6 @@ var commandValues rsapi.ActionCommands
 // RegisterCommands registers all commands with the kinpin application.
 func RegisterCommands(registrar rsapi.APICommandRegistrar) {
 	commandValues = rsapi.ActionCommands{}
-	setupMetadata()
 	registrar.RegisterActionCommands(APIName, GenMetadata, commandValues)
 }
 


### PR DESCRIPTION
@sheldon-b fix concurrent map write crash
looks like we reinitialized the same global for ss and ca package every time a new client was created
should only have to initialize once for each package
