### PR TITLE
Go18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 # uploaded version. (Note: nothing is automatically garbage collected.)
 language: go
 go:
-  - 1.7
+  - 1.8
 env:
   global:
     # RSBIN_KEY= to upload to rightscale-binaries bucket in q&b acct:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a7c2e4bdce40ff2afcc0894cbb72b546f5cfce84129c5776b76a3d860a8de2e6
-updated: 2017-03-07T10:25:52.639682724-08:00
+hash: 51d0757e9a496a666f5d7353cbc4653c80774fed2187f7a8b56f481a606ea114
+updated: 2017-03-07T11:05:54.751055562-08:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
@@ -25,6 +25,20 @@ imports:
   version: acb9493f2794fd0f820de7a27a217dafbb1b65ea
 - name: github.com/mattn/go-isatty
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+- name: github.com/rightscale/go-jsonselect
+  version: d04eebe26072b09f780b43c72c6df71b12b8d105
+- name: golang.org/x/net
+  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
+  subpackages:
+  - context
+  - context/ctxhttp
+- name: golang.org/x/sys
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  subpackages:
+  - unix
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
+testImports:
 - name: github.com/onsi/ginkgo
   version: ab07225d112dc7a93c289ac5b2e12735c2c46035
   subpackages:
@@ -59,19 +73,5 @@ imports:
   - matchers/support/goraph/edge
   - matchers/support/goraph/node
   - matchers/support/goraph/util
-- name: github.com/rightscale/go-jsonselect
-  version: d04eebe26072b09f780b43c72c6df71b12b8d105
-- name: golang.org/x/net
-  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
-  subpackages:
-  - context
-  - context/ctxhttp
-- name: golang.org/x/sys
-  version: e48874b42435b4347fc52bdee0424a52abc974d7
-  subpackages:
-  - unix
-- name: gopkg.in/alecthomas/kingpin.v2
-  version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
-testImports:
 - name: gopkg.in/yaml.v2
   version: a3f3340b5840cee44f372bddb5880fcbc419b46a

--- a/glide.lock
+++ b/glide.lock
@@ -1,32 +1,32 @@
-hash: 5152df8a440ee656e3c1694e39d105db2e927f7020dcbd02d443d3eb5a4de92a
-updated: 2016-09-06T15:06:11.312724078-07:00
+hash: a7c2e4bdce40ff2afcc0894cbb72b546f5cfce84129c5776b76a3d860a8de2e6
+updated: 2017-03-07T10:25:52.639682724-08:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
 - name: github.com/alecthomas/template
-  version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
   subpackages:
   - parse
 - name: github.com/alecthomas/units
-  version: 6b4e7dc5e3143b85ea77909c72caf89416fc2915
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/coddingtonbear/go-simplejson
   version: a582018feafb39c4884d1b03cad98b91e2804276
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/golang/protobuf
-  version: 68415e7123da32b07eab49c96d2c4d6158360e9b
+  version: c9c7427a2a70d2eb3bafa0ab2dc163e45f143317
   subpackages:
   - proto
 - name: github.com/inconshreveable/log15
-  version: f1f14b426c23e20a73468078b52d0713a16a132a
+  version: 39bacc234bf1afd0b68573e95b45871f67ba2cd4
   subpackages:
   - term
 - name: github.com/mattn/go-colorable
-  version: 40e4aedc8fabf8c23e040057540867186712faa5
+  version: acb9493f2794fd0f820de7a27a217dafbb1b65ea
 - name: github.com/mattn/go-isatty
-  version: ae0b1f8f8004be68d791a576e3d8e7648ab41449
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
 - name: github.com/onsi/ginkgo
-  version: 17ea479729ee427265ac1e913443018350946ddf
+  version: ab07225d112dc7a93c289ac5b2e12735c2c46035
   subpackages:
   - config
   - internal/codelocation
@@ -42,8 +42,10 @@ imports:
   - internal/leafnodes
   - internal/spec
   - internal/specrunner
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
 - name: github.com/onsi/gomega
-  version: 0fe204460da2c8fa1babcaac196e694de8f1aaa1
+  version: 1de7ab2df9105aa5c15c4d7e14a8a514e3cb8d4b
   subpackages:
   - ghttp
   - internal/assertion
@@ -60,14 +62,16 @@ imports:
 - name: github.com/rightscale/go-jsonselect
   version: d04eebe26072b09f780b43c72c6df71b12b8d105
 - name: golang.org/x/net
-  version: 66f0418ca41253f8d1a024eb9754e9441a8e79b9
+  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
   subpackages:
   - unix
 - name: gopkg.in/alecthomas/kingpin.v2
   version: e9044be3ab2a8e11d4e1f418d12f0790d57e8d70
-testImports: []
+testImports:
+- name: gopkg.in/yaml.v2
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,29 +1,18 @@
 package: github.com/rightscale/rsc
 import:
 - package: bitbucket.org/pkg/inflect
-  version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
 - package: github.com/alecthomas/template
-  version: b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0
 - package: github.com/alecthomas/units
-  version: 6b4e7dc5e3143b85ea77909c72caf89416fc2915
 - package: github.com/coddingtonbear/go-simplejson
-  version: a582018feafb39c4884d1b03cad98b91e2804276
 - package: github.com/mattn/go-colorable
-  version: 40e4aedc8fabf8c23e040057540867186712faa5
 - package: github.com/mattn/go-isatty
-  version: ae0b1f8f8004be68d791a576e3d8e7648ab41449
 - package: github.com/golang/protobuf
-  version: 68415e7123da32b07eab49c96d2c4d6158360e9b
   subpackages:
   - proto
 - package: github.com/onsi/ginkgo
-  version: 17ea479729ee427265ac1e913443018350946ddf
 - package: github.com/onsi/gomega
-  version: 0fe204460da2c8fa1babcaac196e694de8f1aaa1
 - package: github.com/rightscale/go-jsonselect
-  version: d04eebe26072b09f780b43c72c6df71b12b8d105
 - package: golang.org/x/net
-  version: 66f0418ca41253f8d1a024eb9754e9441a8e79b9
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,8 +9,6 @@ import:
 - package: github.com/golang/protobuf
   subpackages:
   - proto
-- package: github.com/onsi/ginkgo
-- package: github.com/onsi/gomega
 - package: github.com/rightscale/go-jsonselect
 - package: golang.org/x/net
   subpackages:
@@ -19,3 +17,7 @@ import:
 - package: gopkg.in/alecthomas/kingpin.v2
   version: ^2.0.12
 - package: github.com/inconshreveable/log15
+testImport:
+- package: github.com/onsi/ginkgo
+- package: github.com/onsi/gomega
+


### PR DESCRIPTION
Don't lock down to shas in glide.yaml, it can mess up projects using this as a client library.