### PR TITLE
Mask the refresh token in setup process

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,7 +76,7 @@ func CreateConfig(path string) error {
 			config.LoginHost = "my.rightscale.com"
 		}
 		hostDef = fmt.Sprintf(" (%v)", config.LoginHost)
-		refreshTokenDef = fmt.Sprintf(" (%v)", config.RefreshToken)
+		refreshTokenDef = " (leave blank to leave unchanged)"
 	} else {
 		config = &ClientConfig{}
 	}


### PR DESCRIPTION
This was accidentally left out of PR #102, adding now to secure the refresh token on the client machine.