### PR TITLE
Fix resource href parsing to correctly exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+unreleased changes
+-------------------
+* Fix a bug command line resource href matching where actions whose href pattern partially matched the href were
+  considered a full match resulting in the wrong resource action being selected.
+
 v6.4.1 / 2017-06-20
 -------------------
 * Fix bug introduced with storing refresh token in `~/.rsc` where it took precedence over the `-r`/`--refresh-token`

--- a/metadata/action.go
+++ b/metadata/action.go
@@ -32,11 +32,16 @@ func (a *Action) PayloadParamNames() []string {
 	return a.paramsByLocation(PayloadParam)
 }
 
-// MatchHref returns true if the given href
+// MatchHref returns true if the given href matches one of the action's href patterns exactly
 func (a *Action) MatchHref(href string) bool {
+	hrefs := []string{href, href + "/"}
 	for _, pattern := range a.PathPatterns {
-		if pattern.Regexp.MatchString(href) || pattern.Regexp.MatchString(href+"/") {
-			return true
+		for _, href := range hrefs {
+			indices := pattern.Regexp.FindStringIndex(href)
+			// it is only an exact match if the pattern matches from the beginning to the length of the string
+			if indices != nil && indices[0] == 0 && indices[1] == len(href) {
+				return true
+			}
 		}
 	}
 	return false

--- a/recording_test.go
+++ b/recording_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -81,14 +80,16 @@ var _ = Describe("Recorded request", func() {
 			SetOutput(&stdoutBuf)
 			exitCode := 99
 			osExit = func(code int) { exitCode = code }
-			SetErrorOutput(ioutil.Discard)
+			stderrBuf := bytes.Buffer{}
+			SetErrorOutput(&stderrBuf)
 
 			main()
 
 			// Verify that stdout and the exit code are correct
 			//fmt.Fprintf(os.Stderr, "Exit %d %d\n", exitCode, testCase.ExitCode)
 			//fmt.Fprintf(os.Stderr, "stdout got <<%q>>\n  expected <<%q>>\n",
-			//stdoutBuf.String(), testCase.Stdout)
+			//	stdoutBuf.String(), testCase.Stdout)
+			//fmt.Fprintf(os.Stderr, "stderr got <<%q>>\n", stderrBuf.String())
 			Ω(exitCode).Should(Equal(testCase.ExitCode), "Exit code doesn't match")
 			Ω(stdoutBuf.String()).Should(Equal(testCase.Stdout), "Stdout doesn't match")
 		})

--- a/rsapi/commands.go
+++ b/rsapi/commands.go
@@ -359,20 +359,16 @@ func (a *API) parseResource(cmd, hrefPrefix string, commandValues ActionCommands
 
 	var vars []*metadata.PathVariable
 	var candidates []*metadata.Resource
+Metadata:
 	for _, res := range a.Metadata {
 		if v, err := res.ExtractVariables(href); err == nil {
 			vars = v
-			exact := false
 			for _, a := range res.Actions {
 				if a.Name == actionName && a.MatchHref(href) {
 					// We found an exact match!
 					candidates = []*metadata.Resource{res}
-					exact = true
-					break
+					break Metadata
 				}
-			}
-			if exact {
-				break
 			}
 			candidates = append(candidates, res)
 		}


### PR DESCRIPTION
- The code for matching an href with the right resource and action
  assumed that the MatchHref method actually checked for exact matches;
  however, this was not actually the case even though it seems to be the
  intention so I fixed MatchHref to actually return true only when there
  is an exact match.
- I also cleaned up the exact match code to use Golang's labelled break
  feature.