### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM busybox:1.27-glibc
+
+# first, download and extract (or build rsc locally)
+# https://binaries.rightscale.com/rsbin/rsc/v6/rsc-linux-amd64.tgz
+COPY rsc/rsc /usr/local/bin/rsc
+
+WORKDIR /usr/local/bin
+
+CMD ["--help"]
+
+ENTRYPOINT ["rsc"]


### PR DESCRIPTION
Uses the glibc version of the busybox image to be as small as possible.