### PR TITLE
Better RELEASING.md to deal with govers vendor bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cm15/examples/rsssh/rsssh
 ss/examples/basic/basic
 vendor/
 .glide/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUCKET=rightscale-binaries
 ACL=public-read
 # version for gopkg.in, e.g. v1, v2, ...
 GOPKG_VERS=v6
-GLIDE_VERSION?=v0.11.1
+GLIDE_VERSION?=v0.13.1
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
 ifeq (windows,$(GOOS))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,12 +11,16 @@ If making a major release version, change `GOPKG_VERS` in Makefile.
 In order to cut a release branch from master, the steps are:
 ```
 git checkout -b v2.3.4
+rm -rf vendor/
 make govers
 git commit -a -m 'add import constraints for release v2.3.4'
 git push origin v2.3.4
 ```
 This will trigger a CI build which will upload the new version binaries. Also creating the remote
-branch means that `gopkg.in` will get the newly released code for the major version.
+branch means that `gopkg.in` will get the newly released code for the major version. We remove the
+`vendor` directory in order to avoid a bug in `govers` that tries to look at files in the directory
+causing it to miss the top level directory `.go` files. You can run `make depend` to restore `vendor`
+after releasing.
 
 ### Test a release
 


### PR DESCRIPTION
- Add step to remove `vendor` directory before running `make govers` in
  RELEASING.md to work around it looking there, messing up, and missing
  the top level directory. This is the message that `govers` would print
  but not actually return an error on:
  ```
  govers: cannot import "github.com/rightscale/rsc/vendor/github.com/onsi/ginkgo/integration/_fixtures/convert_goldmasters" from "/home/douglas/go/src/github.com/rightscale/rsc": found packages tmp (extra_functions_test.go) and subpackage (nested_subpackage_test.go) in /home/douglas/go/src/github.com/rightscale/rsc/vendor/github.com/onsi/ginkgo/integration/_fixtures/convert_goldmasters
  ```
- Update to latest Glide.
- Add evil `.DS_Store` to `.gitignore`. How did this not happen already?