### PR TITLE
allow setting of user-agent in http(s) request

### DIFF
--- a/httpclient/http.go
+++ b/httpclient/http.go
@@ -270,7 +270,12 @@ func (d *dumpClient) doImp(req *http.Request, hidden bool, ctx context.Context) 
 			req.URL.Scheme = "https"
 		}
 	}
-	req.Header.Set("User-Agent", UA)
+
+	//set user-agent if one is not provided.
+	ua := req.Header.Get("User-Agent")
+	if ua == "" {
+		req.Header.Set("User-Agent", UA)
+	}
 
 	var reqBody []byte
 	startedAt := time.Now()


### PR DESCRIPTION
Allow the User-Agent header to be passed from plugins to aws cloudtrails.