### PR TITLE
Improve RubyTime predictability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@
 # uploaded version. (Note: nothing is automatically garbage collected.)
 language: go
 go:
-  - 1.12.x
-dist: bionic
+  - 1.14.x
 env:
   global:
     # RSBIN_KEY= to upload to rightscale-binaries bucket in q&b acct:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v8.0.0 / 2020-03-19
+-------------------
+* Make the parsing of `RubyTime` for `cm15` more predictable by using [`time.ParseInLocation`](https://golang.org/pkg/time/#ParseInLocation) with `time.UTC`
+* Build with Go 1.14.x.
+
 v7.0.1 / 2019-11-15
 -------------------
 * Refreshed policy API actions

--- a/cm15/ruby_time.go
+++ b/cm15/ruby_time.go
@@ -19,7 +19,7 @@ func (r *RubyTime) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the unmarshaller interface.
 func (r *RubyTime) UnmarshalJSON(b []byte) (err error) {
 	s := string(b)
-	t, err := time.Parse("2006/01/02 15:04:05 -0700", s[1:len(s)-1])
+	t, err := time.ParseInLocation("2006/01/02 15:04:05 -0700", s[1:len(s)-1], time.UTC)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- With the previous implementation, `RubyTime` objects would not necessarily have the location set to `time.UTC` depending on the time zone settings where they are run. This is definitely a problem when trying to write unit tests for things using `cm15` objects.