### PR TITLE
Add mediatype attribute data to generated metadata (#75)

### DIFF
--- a/gen/writers/metadata.go
+++ b/gen/writers/metadata.go
@@ -86,12 +86,15 @@ import (
 
 `
 
-const resourceMetadataTmpl = `{{define "action"}}` + actionMetadataTmpl + `{{end}}// Consists of a map of resource name to resource metadata.
+const resourceMetadataTmpl = `{{define "action"}}` + actionMetadataTmpl + `{{end}}{{define "attribute"}}` + attributeMetadataTmpl + `{{end}}// Consists of a map of resource name to resource metadata.
 var GenMetadata = map[string]*metadata.Resource{ {{range .}}
 	"{{.Name}}": &metadata.Resource{
 		Name: "{{.Name}}",
 		Description: ` + "`" + `{{escapeBackticks .Description}}` + "`" + `,
 		Identifier: "{{.Identifier}}",
+		Attributes: []*metadata.Attribute{ {{range .Attributes}}
+		{{template "attribute" . }}{{end}}
+		},
 		Actions: []*metadata.Action{ {{range .Actions}}
 		{{template "action" .}}{{end}}
 		},{{if .Links}}
@@ -138,5 +141,12 @@ const actionMetadataTmpl = `&metadata.Action {
 						ValidValues: []string{"{{join (toStringArray .ValidValues) "\", \""}}"},{{end}}
 					},{{end}}
 				},
+			},
+`
+
+const attributeMetadataTmpl = `&metadata.Attribute {
+				Name: "{{.Name}}",
+				FieldName: "{{.FieldName}}",
+				FieldType: "{{.FieldType}}",
 			},
 `

--- a/metadata/attribute.go
+++ b/metadata/attribute.go
@@ -1,0 +1,7 @@
+package metadata
+
+type Attribute struct {
+	Name      string // Attribute name, e.g. "elasticity_params"
+	FieldName string // Corresponding go struct field name, e.g. "ElasticityParams"
+	FieldType string // Corresponding go struct type, e.g. "*ElasticityParams"
+}

--- a/metadata/resource.go
+++ b/metadata/resource.go
@@ -10,6 +10,7 @@ import (
 type Resource struct {
 	Name        string
 	Description string
+	Attributes  []*Attribute
 	Actions     []*Action
 	Identifier  string
 	Links       map[string]string


### PR DESCRIPTION
* Add mediatype attribute data to generated metadata

* Actually merge with rightscale master (oops)

Co-authored-by: Geyer <>